### PR TITLE
make sure muted is checked and disabled

### DIFF
--- a/acf-cloudflare-stream/assets/js/field.js
+++ b/acf-cloudflare-stream/assets/js/field.js
@@ -78,6 +78,62 @@
 		});
 	}
 
+	/**
+	 * Handle play_scrolled_into_view relationship with muted and loop
+	 * When play_scrolled_into_view is checked, muted and loop must be checked and disabled
+	 */
+	function handlePlayScrolledIntoViewRelationship($field) {
+		const $playScrolledCheckbox = $field.find('.data-play-scrolled-into-view');
+		const $mutedCheckbox = $field.find('.data-muted');
+		const $loopCheckbox = $field.find('.data-loop');
+		const $mutedHidden = $field.find('input[type="hidden"][name*="[muted]"]');
+		const $loopHidden = $field.find('input[type="hidden"][name*="[loop]"]');
+
+		// Function to update muted and loop state based on play_scrolled_into_view
+		function updateDependentStates() {
+			if ($playScrolledCheckbox.is(':checked')) {
+				// Check and disable muted and loop checkboxes
+				$mutedCheckbox.prop('checked', true);
+				$loopCheckbox.prop('checked', true);
+				$mutedCheckbox.prop('disabled', true);
+				$loopCheckbox.prop('disabled', true);
+				// Ensure hidden fields have correct values
+				$mutedHidden.val('1');
+				$loopHidden.val('1');
+			} else {
+				// Re-enable muted and loop checkboxes
+				$mutedCheckbox.prop('disabled', false);
+				$loopCheckbox.prop('disabled', false);
+			}
+		}
+
+		// Initialize on load
+		updateDependentStates();
+
+		// Watch for changes to play_scrolled_into_view
+		$playScrolledCheckbox.off('change.playScrolled').on('change.playScrolled', function() {
+			updateDependentStates();
+		});
+
+		// Prevent unchecking muted when play_scrolled_into_view is checked
+		$mutedCheckbox.off('change.playScrolledMuted').on('change.playScrolledMuted', function() {
+			if ($playScrolledCheckbox.is(':checked') && !$(this).is(':checked')) {
+				// Force it back to checked
+				$(this).prop('checked', true);
+				$mutedHidden.val('1');
+			}
+		});
+
+		// Prevent unchecking loop when play_scrolled_into_view is checked
+		$loopCheckbox.off('change.playScrolledLoop').on('change.playScrolledLoop', function() {
+			if ($playScrolledCheckbox.is(':checked') && !$(this).is(':checked')) {
+				// Force it back to checked
+				$(this).prop('checked', true);
+				$loopHidden.val('1');
+			}
+		});
+	}
+
 	function initialize_field($field) {
 
 		const $fileInput = $field.find('.nsz-cloudflare-stream-file');
@@ -89,6 +145,9 @@
 
 		// Initialize autoplay/muted relationship
 		handleAutoplayMutedRelationship($field);
+
+		// Initialize play_scrolled_into_view relationship with muted and loop
+		handlePlayScrolledIntoViewRelationship($field);
 
 		// Function to delete video from Cloudflare Stream
 		function deleteCloudflareVideo(videoId, listItem, cfs_wrap) {

--- a/nsz-design-video-field.php
+++ b/nsz-design-video-field.php
@@ -5,7 +5,7 @@
  *
  * Plugin Name: 970 Design Video Field
  * Description: An Advanced Custom Fields (ACF) Field for Cloudflare Stream.
- * Version:     1.42
+ * Version:     1.43
  * Author:      970Design
  * Author URI:  https://970design.com/
  * License:     GPLv2 or later


### PR DESCRIPTION
Muted was being checked already but not disabled, nor was the hidden field getting updated if autoplay is checked. These values are necessary for dynamic data on the front end.

What this does is force the muted to be enabled and not editable if autoplay is checked. This enforces the proper attribute values for the front end. Since we're converting our front end sections to fetch all of these attributes dynamically, this will make the video component(s) safe.

Nothing new is necessary for the npm package.

Oh, bumped the version. 🔢 